### PR TITLE
13 readonly fix

### DIFF
--- a/p4p_ext/rules.py
+++ b/p4p_ext/rules.py
@@ -172,7 +172,7 @@ class BaseRule(ABC):
     # of a valueAlarm rule. The combination of listing fields controlled by the
     # rule and having a readonly flag allows this to be automatically handled by
     # this base class's put_rule()
-    read_only: bool = False
+    read_only: bool = True
 
     # TODO: Consider using lru_cache but be aware of https://rednafi.com/python/lru_cache_on_methods/
     def is_applicable(self, newpvstate: Value) -> bool:

--- a/p4p_ext/rules.py
+++ b/p4p_ext/rules.py
@@ -244,7 +244,7 @@ class BaseRule(ABC):
                 # The second step prevents changes being made.
                 for changed_field in newpvstate.changedSet():
                     if changed_field.startswith(field):
-                        newpvstate[changed_field] = oldpvstate[changed_field]
+                        newpvstate[changed_field] = pv.current().raw[changed_field]
                         newpvstate.mark(changed_field, False)
 
         return RulesFlow.CONTINUE

--- a/p4p_ext/rules.py
+++ b/p4p_ext/rules.py
@@ -172,7 +172,7 @@ class BaseRule(ABC):
     # of a valueAlarm rule. The combination of listing fields controlled by the
     # rule and having a readonly flag allows this to be automatically handled by
     # this base class's put_rule()
-    read_only: bool = True
+    read_only: bool = False
 
     # TODO: Consider using lru_cache but be aware of https://rednafi.com/python/lru_cache_on_methods/
     def is_applicable(self, newpvstate: Value) -> bool:

--- a/tests/integration/thread/test_ntscalar.py
+++ b/tests/integration/thread/test_ntscalar.py
@@ -135,6 +135,9 @@ def test_alarm_limit_change_readonly(basic_server, ctx):
     pv_double1.set_alarm_limits(**alarm_config)
     basic_server.add_pv(pvname, pv_double1)
 
+    # TODO: This is a very messy way of making a rule not read_only!
+    basic_server[pvname]._handler["alarm_limit"].read_only = True
+
     basic_server.start()
 
     ctx.put(pvname, -5)

--- a/tests/integration/thread/test_ntscalar.py
+++ b/tests/integration/thread/test_ntscalar.py
@@ -180,6 +180,37 @@ def test_field_change(pvname, server_from_yaml, pv_config, ctx):
         pytest.xfail("Unsure on expected behaviour for read-only field changes")
 
 
+def test_alarm_limit_change_readonly(basic_server, ctx):
+    # for each PV that is alarmed, we change the upper alarm limit on the PV
+    # and check if setting the value to something above/below that triggers
+    # the correct alarm state
+    pvname = "TEST:ALARM:LIMIT:PV"
+
+    alarm_config = {
+        "low_alarm": -9,
+        "low_warning": -4,
+        "high_warning": 4,
+        "high_alarm": 9,
+    }
+    pv_double1 = PVScalarRecipe(PVTypes.DOUBLE, "An example alarmed PV", 0)
+    pv_double1.set_alarm_limits(**alarm_config)
+    basic_server.add_pv(pvname, pv_double1)
+
+    basic_server.start()
+
+    ctx.put(pvname, -5)
+    assert_pv_in_minor_alarm_state(pvname, ctx)
+
+    put_metadata(ctx, pvname, "valueAlarm.lowWarningLimit", -6)
+    assert_pv_in_minor_alarm_state(pvname, ctx)
+
+    ctx.put(pvname, -10)
+    assert_pv_in_major_alarm_state(pvname, ctx)
+
+    put_metadata(ctx, pvname, "valueAlarm.lowAlarmLimit", -11)
+    assert_pv_in_major_alarm_state(pvname, ctx)
+
+
 def test_alarm_limit_change(basic_server, ctx):
     # for each PV that is alarmed, we change the upper alarm limit on the PV
     # and check if setting the value to something above/below that triggers
@@ -195,6 +226,9 @@ def test_alarm_limit_change(basic_server, ctx):
     pv_double1 = PVScalarRecipe(PVTypes.DOUBLE, "An example alarmed PV", 0)
     pv_double1.set_alarm_limits(**alarm_config)
     basic_server.add_pv(pvname, pv_double1)
+
+    # TODO: This is a very messy way of making a rule not read_only!
+    basic_server[pvname]._handler["alarm_limit"].read_only = False
 
     basic_server.start()
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -250,7 +250,8 @@ class TestControl:
         ):
             sharedpv.current.return_value = nt.unwrap(old_state)
             server_op.value.return_value = nt.unwrap(new_state)
-            result = rule.put_rule(sharedpv, server_op)
+            result = rule.put_rule(sharedpv, server_op)  # New rules no long auto-call post_rule
+            result = rule.post_rule(old_state, new_state)
 
         assert result is RulesFlow.CONTINUE
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -216,6 +216,49 @@ class TestControl:
                 for item in zip(expected_log, caplog.records[expected_log_index:3:]):
                     assert item[0] in item[1].getMessage()
 
+    @pytest.mark.parametrize(
+        "nttype, control_changes, expected_value, read_only",
+        [
+            ("d", [-6, -5, 5, 2], -5, True),
+            ("d", [-6, -5, 5, 2], -5, False),
+            ("d", [-7, -10, 5, 2], -5, True),
+            ("d", [-7, -10, 5, 2], -7, False),
+        ],
+    )
+    def test_control_change_with_put(self, nttype, control_changes, expected_value, read_only):
+        nt = NTScalar(nttype, control=True)
+        control_limits = {"limitLow": -5, "limitHigh": 5, "minStep": 2}
+        if not nttype.startswith("a"):
+            rule = ControlRule()
+            old_state = nt.wrap({"value": 0.0, "control": control_limits})
+        else:
+            rule = ScalarToArrayWrapperRule(ControlRule())
+            old_state = nt.wrap({"value": [0.0, 0.0, 0.0], "control": control_limits})
+        rule.read_only = read_only
+
+        control_limits = {
+            "limitLow": control_changes[1],
+            "limitHigh": control_changes[2],
+            "minStep": control_changes[3],
+        }
+        new_state = nt.wrap({"value": control_changes[0], "control": control_limits})
+        overwrite_unmarked(old_state, new_state)
+
+        with (
+            patch("p4p.server.raw.SharedPV", autospec=True) as sharedpv,
+            patch("p4p.server.ServerOperation", autospec=True) as server_op,
+        ):
+            sharedpv.current.return_value = nt.unwrap(old_state)
+            server_op.value.return_value = nt.unwrap(new_state)
+            result = rule.put_rule(sharedpv, server_op)
+
+        assert result is RulesFlow.CONTINUE
+
+        if not nttype.startswith("a"):
+            assert new_state["value"] == expected_value
+        else:
+            numpy.testing.assert_array_equal(new_state["value"], expected_value)
+
 
 class TestAlarmLimit:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #13 

The readonly flags for the rules weren't working properly. This fixes the problem and adds unit tests to confirm that the fix is good (and no future regressions occur).